### PR TITLE
Fix loot table for end prosperity ore with silk touch

### DIFF
--- a/src/main/resources/data/mysticalagradditions/loot_tables/blocks/end_prosperity_ore.json
+++ b/src/main/resources/data/mysticalagradditions/loot_tables/blocks/end_prosperity_ore.json
@@ -2,7 +2,7 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "name": "mysticalagradditions:nether_prosperity_ore",
+      "name": "mysticalagradditions:end_prosperity_ore",
       "rolls": 1,
       "entries": [
         {


### PR DESCRIPTION
I couldn't get the JAR to build for testing, but this seems like a straightforward patch.

There's a bunch of unresolved dependencies. I guess those are in your `libs/` folder?