### PR TITLE
Add loot table for Nitro Crystal Crux

### DIFF
--- a/src/main/resources/data/mysticalagradditions/loot_tables/blocks/nitro_crystal_crux.json
+++ b/src/main/resources/data/mysticalagradditions/loot_tables/blocks/nitro_crystal_crux.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "name": "mysticalagradditions:nitro_crystal_crux",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "mysticalagradditions:nitro_crystal_crux"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Nitro Crystal Crux currently drops nothing when broken, adding a loot table to resolve that.